### PR TITLE
Add values.yaml specific to different cluster environments

### DIFF
--- a/charts/rcloud/templates/NOTES.txt
+++ b/charts/rcloud/templates/NOTES.txt
@@ -1,6 +1,17 @@
 1. Access the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
   Open {{ include "rcloud.consoleFQDNWithScheme" . }} in browser.
+{{- else if .Values.deploy.contour.enable }}
+  {{- if (eq (index .Values.contour.envoy.service.annotations "service.beta.kubernetes.io/aws-load-balancer-type" | toString ) "nlb") }}
+  Get load balancer address via:
+  kubectl get service envoy --namespace {{ .Release.Namespace }} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+
+  Add DNS records of following domains such that it resolves to above address:
+  - {{ include "rcloud.consoleFQDN" . }}
+  - {{ include "rcloud.coreConnectorFQDN" . }}
+  - {{ include "rcloud.userFQDN" . }}
+  {{- end }}
+  Open {{ include "rcloud.consoleFQDNWithScheme" . }} in browser.
 {{- else if contains "NodePort" .Values.services.rcloudConsoleUI.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services rcloud-console-ui)
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/rcloud/values.yaml
+++ b/charts/rcloud/values.yaml
@@ -502,3 +502,8 @@ contour:
     # solve this.
     # https://github.com/RafayLabs/rcloud-helm/issues/13
     manageCRDs: false
+
+  envoy:
+    service:
+      # -- Annotations for Envoy service.
+      annotations: {}

--- a/examples/values.domains.yaml
+++ b/examples/values.domains.yaml
@@ -1,0 +1,5 @@
+ingress:
+  host: rafay.local
+  consoleSubdomain: "console"
+  coreConnectorSubdomain: "*.core-connector"
+  userSubdomain: "*.user"

--- a/examples/values.eks.yaml
+++ b/examples/values.eks.yaml
@@ -1,0 +1,21 @@
+## This is an example values used to overwrite default values.yaml
+## for deploying chart on AWS EKS cluster.
+##
+## contour on AWS with NLB: https://projectcontour.io/guides/deploy-aws-nlb/
+
+ingress:
+  enabled: false
+
+deploy:
+  elasticsearch:
+    enable: true
+  postgresql:
+    enable: true
+  contour:
+    enable: true
+
+contour:
+  envoy:
+    service:
+      annotations:
+        service.beta.kubernetes.io/aws-load-balancer-type: nlb

--- a/examples/values.host-hetwork.yaml
+++ b/examples/values.host-hetwork.yaml
@@ -1,0 +1,23 @@
+## This is an example values used to overwrite default values.yaml for
+## allowing contour/envoy service on host network.
+
+ingress:
+  enabled: false
+
+deploy:
+  elasticsearch:
+    enable: true
+  postgresql:
+    enable: true
+  contour:
+    enable: true
+
+contour:
+  envoy:
+    hostNetwork: true
+    dnsPolicy: ClusterFirstWithHostNet
+    containerPorts:
+      http: 80
+      https: 443
+    containerSecurityContext:
+      runAsUser: 0

--- a/examples/values.kind.yaml
+++ b/examples/values.kind.yaml
@@ -1,0 +1,17 @@
+## This is an example values used to overwrite default values.yaml
+## for deploying chart on a Kind cluster.
+
+ingress:
+  enabled: false
+
+deploy:
+  elasticsearch:
+    enable: true
+  postgresql:
+    enable: true
+  contour:
+    enable: true
+
+kratos:
+  kratos:
+    development: true


### PR DESCRIPTION
Added following values.yaml for specific cluster type:
- values.eks.yaml             => AWS EKS cluster
- values.kind.yaml            => local Kind cluster
- values.host-hetwork.yaml    => Run envoy to access host network
- values.domains.yaml         => Domains and subdomains to set