### PR TITLE
Fix: Update helper functions to take contour into account

### DIFF
--- a/charts/rcloud/Chart.yaml
+++ b/charts/rcloud/Chart.yaml
@@ -25,5 +25,5 @@ dependencies:
     condition: deploy.contour.enable
 maintainers:
   - name: Rafay
-version: 0.0.1-alpha
+version: 0.0.1-alpha.1
 appVersion: "v0.0.1"

--- a/charts/rcloud/templates/_helpers.tpl
+++ b/charts/rcloud/templates/_helpers.tpl
@@ -147,22 +147,40 @@ Get console full-qualified domain.
 Get console full-qualified domain with scheme.
 */}}
 {{- define "rcloud.consoleFQDNWithScheme" -}}
-{{- if .Values.ingress.tls -}}
-https://{{.Values.ingress.consoleSubdomain}}.{{.Values.ingress.host}}
-{{- else -}}
-http://{{.Values.ingress.consoleSubdomain}}.{{.Values.ingress.host}}
-{{- end -}}
+{{- $url := printf "%s.%s" .Values.ingress.consoleSubdomain .Values.ingress.host -}}
+  {{- if .Values.deploy.contour.enable -}}
+    {{- if .Values.deploy.contour.tls -}}
+https://{{$url}}
+    {{- else -}}
+http://{{$url}}
+    {{- end -}}
+  {{- else if .Values.ingress.enabled -}}
+    {{- if .Values.ingress.tls -}}
+https://{{$url}}
+    {{- else -}}
+http://{{$url}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*
 Get console full-qualified domain with port.
 */}}
 {{- define "rcloud.consoleFQDNWithPort" -}}
-{{- if .Values.ingress.tls -}}
-{{.Values.ingress.consoleSubdomain}}.{{.Values.ingress.host}}:443
-{{- else -}}
-{{.Values.ingress.consoleSubdomain}}.{{.Values.ingress.host}}:80
-{{- end -}}
+{{- $url := printf "%s.%s" .Values.ingress.consoleSubdomain .Values.ingress.host -}}
+  {{- if .Values.deploy.contour.enable -}}
+    {{- if .Values.deploy.contour.tls -}}
+{{$url}}:443
+    {{- else -}}
+{{$url}}:80
+    {{- end -}}
+  {{- else if .Values.ingress.enabled -}}
+    {{- if .Values.ingress.tls -}}
+{{$url}}:443
+    {{- else -}}
+{{$url}}:80
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
When contour is enabled, consider contour settings for generating
cosole url. for example, 443 or 80 port in console is added based on
contour tls status. Otherwise, ingress tls status is taken into
account to generate console url by helper functions.