### PR TITLE
Update NOTES.txt

### DIFF
--- a/charts/ztka/templates/NOTES.txt
+++ b/charts/ztka/templates/NOTES.txt
@@ -2,16 +2,18 @@
 {{- if .Values.ingress.enabled }}
   Open {{ include "ztka.consoleFQDNWithScheme" . }} in browser.
 {{- else if .Values.deploy.contour.enable }}
-  {{- if (eq (index .Values.contour.envoy.service.annotations "service.beta.kubernetes.io/aws-load-balancer-type" | toString ) "nlb") }}
-  Get load balancer address via:
-  kubectl get service {{ .Release.Name }}-contour-envoy --namespace {{ .Release.Namespace }} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+  Get the EXTERNAL-IP value using following command:
+  kubectl get service {{ .Release.Name }}-contour-envoy -n {{ .Release.Namespace }}
 
-  Add DNS records of following domains such that it resolves to above address:
+  Add DNS records of following domains such that it resolves to above <EXTERNAL-IP> value:
   - {{ include "ztka.consoleFQDN" . }}
   - {{ include "ztka.coreConnectorFQDN" . }}
   - {{ include "ztka.userFQDN" . }}
-  {{- end }}
+
   Open {{ include "ztka.consoleFQDNWithScheme" . }} in browser.
+
+  Note: If you are using a cluster with no load-balancer, then the address will be "<pending>".
+        If it is Kind or Minikube cluster, check out respective docs to get the external address.
 {{- else if contains "NodePort" .Values.services.dashboard.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services dashboard)
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")


### PR DESCRIPTION
### What does this PR change?
Add a note for the cluster environment witout load-balancer and user
enabled contour.

If contour is enabled:

case 1: EKS/AKS/GKE cluster (with loadbalancer)
  Get the contour-envoy loadbalancer address. Use it for DNS record.

case 2: Kind/Minikube cluster (without loadbalancer)
  contout-envoy loadbalancer address is `<pending>`. User has to get
  address using `minikube ip` or `docker container inspect ..` commands.


### Does the PR depend on any other PRs or Issues? If yes, please list them.
None.

### Checklist

I confirm, that I have...

- [X] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
- [X] Ran [`helm-docs`](https://github.com/norwoodj/helm-docs) to update docs for chart (if values.yaml file was changed)
