### PR TITLE
Restart kratos on upgrade and rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 ### Added
+- Helm upgrade & rollback hook to restart Kratos from [akshay196](https://github.com/akshay196)
 ### Changed
 ### Fixed
 

--- a/charts/ztka/templates/job-kratos-hooks.yaml
+++ b/charts/ztka/templates/job-kratos-hooks.yaml
@@ -1,0 +1,62 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kratos-restart
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: post-upgrade,post-rollback
+    helm.sh/hook-weight: "-2"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kratos-restart
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: post-upgrade,post-rollback
+    helm.sh/hook-weight: "-2"
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: ["{{ .Release.Name }}-kratos"]
+    verbs: ["get", "patch", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kratos-restart
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: post-upgrade,post-rollback
+    helm.sh/hook-weight: "-1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kratos-restart
+subjects:
+  - kind: ServiceAccount
+    name: kratos-restart
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kratos-restart
+  annotations:
+    helm.sh/hook: post-upgrade,post-rollback
+    helm.sh/hook-weight: "0"
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 600
+  template:
+    spec:
+      serviceAccountName: kratos-restart
+      restartPolicy: Never
+      containers:
+        - name: kubectl
+          image: bitnami/kubectl
+          command:
+            - 'kubectl'
+            - 'rollout'
+            - 'restart'
+            - 'deployment/{{ .Release.Name }}-kratos'


### PR DESCRIPTION
### What does this PR change?
To reload kratos configurations as env vars, Kratos pod need to be
restart on upgrade and rollback.


### Does the PR depend on any other PRs or Issues? If yes, please list them.
Fixes #41 

### Checklist

I confirm, that I have...

- [X] Read and followed the contributing guide in `CONTRIBUTING.md`
- [x] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [x] Updated `CHANGELOG.md`
- [x] Ran [`helm-docs`](https://github.com/norwoodj/helm-docs) to update docs for chart (if values.yaml file was changed)