### PR TITLE
Drop application logs from relay-tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Helm upgrade & rollback hook to restart Kratos from [akshay196](https://github.com/akshay196)
 ### Changed
 ### Fixed
+- Prevent filebeat from fetching application logs for audit from [meain](https://github.com/meain)
 
 ## [0.1.0] - 2022-06-22
 ### Added

--- a/charts/ztka/values.yaml
+++ b/charts/ztka/values.yaml
@@ -483,6 +483,9 @@ filebeat:
                       fields:
                         paralus.component: relay
                       processors:
+                        - drop_event:
+                            when:
+                              has_fields: ['json.caller']  # these will be application logs
                         - timestamp:
                             field: json.ts
                             layouts:


### PR DESCRIPTION
### What does this PR change?

Previously we were fetching application logs along with audit logs in `filebeat`. This avoid that by filtering out those using a `filebeat` preprocessor.

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [x] Updated `CHANGELOG.md`
- [ ] Ran [`helm-docs`](https://github.com/norwoodj/helm-docs) to update docs for chart (if values.yaml file was changed)
