### PR TITLE
Allow specifying DSN explicitly for external postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Helm upgrade & rollback hook to restart Kratos from [akshay196](https://github.com/akshay196)
 ### Changed
+- Allow explicit setting of postgresql DSN
+
 ### Fixed
 - Prevent filebeat from fetching application logs for audit from [meain](https://github.com/meain)
+- Fixed typo in output of postgresql Password
 
 ## [0.1.0] - 2022-06-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Helm upgrade & rollback hook to restart Kratos from [akshay196](https://github.com/akshay196)
 ### Changed
-- Allow explicit setting of postgresql DSN
+- Allow explicit setting of postgresql DSN from [mcfearsome](https://github.com/mcfearsome) and [meain](https://github.com/meain)
 
 ### Fixed
 - Prevent filebeat from fetching application logs for audit from [meain](https://github.com/meain)
-- Fixed typo in output of postgresql Password
+- Fixed typo in output of postgresql Password from [mcfearsome](https://github.com/mcfearsome)
 
 ## [0.1.0] - 2022-06-22
 ### Added

--- a/charts/ztka/Chart.yaml
+++ b/charts/ztka/Chart.yaml
@@ -26,4 +26,4 @@ dependencies:
 maintainers:
   - name: Paralus Team
 version: "0.1.0"
-appVersion: "v0.1.0"
+appVersion: "v0.1.1"

--- a/charts/ztka/README.md
+++ b/charts/ztka/README.md
@@ -43,11 +43,12 @@ A Helm chart for Paralus ZTKA.
 | deploy.kratos.enable | bool | `true` | Kratos instance is auto deployed and managed by Helm release when true. |
 | deploy.kratos.publicAddr | string | `""` | Kratos public address. Required when `deploy.kratos.enable` is unset |
 | deploy.kratos.smtpConnectionURI | string | `"smtps://test:test@mypost:1025/?skip_ssl_verify=true"` | SMTP connection URI that used by auto-deployed kratos for sending mails for example, account recovery etc. |
-| deploy.postgresql.address | string | `""` | Postgresql address for example, "localhost:5432". Required when `deploy.postgresql.enable` is unset |
-| deploy.postgresql.database | string | `""` | Postgresql database name. Required when `deploy.postgresql.enable` is unset. |
+| deploy.postgresql.address | string | `""` | Postgresql address for example, "localhost:5432". Required when `deploy.postgresql.enable` is unset and dsn is not specified. |
+| deploy.postgresql.database | string | `""` | Postgresql database name. Required when `deploy.postgresql.enable` is unset and dsn is not specified. |
+| deploy.postgresql.dsn | string | `""` | Postgresql DSN for example, "postgres://user:password@host:5432/db". Required when `deploy.postgresql.enable` is unset and individual components are not specified. Overrides individual components (address, username, password, database) |
 | deploy.postgresql.enable | bool | `false` | Postgresql db is auto deployed and managed by Helm release when true. (It is recommended to manage your own DB instance separately or use DB services like Amazon RDS in production) |
-| deploy.postgresql.password | string | `""` | Postgresql password. Required when `deploy.postgresql.enable` is unset. |
-| deploy.postgresql.username | string | `""` | Postgresql username. Required when `deploy.postgresql.enable` is unset. |
+| deploy.postgresql.password | string | `""` | Postgresql password. Required when `deploy.postgresql.enable` is unset and dsn is not specified. |
+| deploy.postgresql.username | string | `""` | Postgresql username. Required when `deploy.postgresql.enable` is unset and dsn is not specified. |
 | elasticsearch.minimumMasterNodes | int | `1` |  |
 | elasticsearch.replicas | int | `1` |  |
 | filebeat | object | filebeat subchart overwrite | the chart will overwrite some values of filebear subchart. |

--- a/charts/ztka/README.md
+++ b/charts/ztka/README.md
@@ -1,6 +1,6 @@
 # ztka
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.1](https://img.shields.io/badge/AppVersion-v0.1.1-informational?style=flat-square)
 
 A Helm chart for Paralus ZTKA.
 
@@ -62,10 +62,10 @@ A Helm chart for Paralus ZTKA.
 | images.dashboard.tag | string | `"v0.1.0"` |  |
 | images.paralus.name | string | `"paralus"` |  |
 | images.paralus.repository | string | `"paralusio/paralus"` | Paralus paralus image |
-| images.paralus.tag | string | `"v0.1.0"` |  |
+| images.paralus.tag | string | `"v0.1.1"` |  |
 | images.paralusInit.name | string | `"paralus-init"` |  |
 | images.paralusInit.repository | string | `"paralusio/paralus-init"` | Paralus paralus initialize image |
-| images.paralusInit.tag | string | `"v0.1.0"` |  |
+| images.paralusInit.tag | string | `"v0.1.1"` |  |
 | images.prompt.name | string | `"prompt"` |  |
 | images.prompt.repository | string | `"paralusio/prompt"` | prompt image |
 | images.prompt.tag | string | `"v0.1.0"` |  |

--- a/charts/ztka/templates/_helpers.tpl
+++ b/charts/ztka/templates/_helpers.tpl
@@ -82,7 +82,7 @@ Get DB Address.
 {{- define "ztka.dbAddr" -}}
   {{- if .Values.deploy.postgresql.enable -}}
 {{.Release.Name}}-postgresql.{{.Release.Namespace}}.svc.cluster.local
-  {{- else -}}
+  {{- else if empty .Values.deploy.postgresql.dsn -}}
 {{ required "A valid .Values.deploy.postgresql.address entry required!" .Values.deploy.postgresql.address }}
   {{- end -}}
 {{- end }}
@@ -93,7 +93,7 @@ Get DB Username.
 {{- define "ztka.dbUser" -}}
   {{- if .Values.deploy.postgresql.enable -}}
 {{.Values.postgresql.auth.username}}
-  {{- else -}}
+  {{- else if empty .Values.deploy.postgresql.dsn -}}
 {{ required "A valid .Values.deploy.postgresql.username entry required!" .Values.deploy.postgresql.username }}
   {{- end -}}
 {{- end }}
@@ -104,7 +104,7 @@ Get DB Password.
 {{- define "ztka.dbPassword" -}}
   {{- if .Values.deploy.postgresql.enable -}}
 {{.Values.postgresql.auth.password}}
-  {{- else -}}
+  {{- else if empty .Values.deploy.postgresql.dsn -}}
 {{ required "A valid .Values.deploy.postgresql.password entry required!" .Values.deploy.postgresql.password }}
   {{- end -}}
 {{- end }}
@@ -115,7 +115,7 @@ Get DB Name.
 {{- define "ztka.dbName" -}}
   {{- if .Values.deploy.postgresql.enable -}}
 {{.Values.postgresql.auth.database}}
-  {{- else -}}
+  {{- else if empty .Values.deploy.postgresql.dsn -}}
 {{ required "A valid .Values.deploy.postgresql.database entry required!" .Values.deploy.postgresql.database }}
   {{- end -}}
 {{- end }}
@@ -126,14 +126,14 @@ Get DSN
 {{- define "ztka.dsn" -}}
   {{- if .Values.deploy.postgresql.enable -}}
 postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{.Release.Name}}-postgresql.{{.Release.Namespace}}.svc.cluster.local:5432/{{ .Values.postgresql.auth.database }}?sslmode=disable
-  {{- else if empty .Values.deploy.postgresql.dsn -}}
+  {{- else if .Values.deploy.postgresql.dsn -}}
+{{ .Values.deploy.postgresql.dsn }}
+  {{- else -}}
 {{- $username := required "A valid .Values.deploy.postgresql.username entry required!" .Values.deploy.postgresql.username -}}
 {{- $password := required "A valid .Values.deploy.postgresql.password entry required!" .Values.deploy.postgresql.password -}}
 {{- $address := required "A valid .Values.deploy.postgresql.address entry required!" .Values.deploy.postgresql.address -}}
 {{- $database := required "A valid .Values.deploy.postgresql.database entry required!" .Values.deploy.postgresql.database -}}
 postgres://{{ $username }}:{{ $password }}@{{ $address }}:5432/{{ $database }}?sslmode=disable
-  {{- else -}}
-{{ .Values.deploy.postgresql.dsn }}
   {{- end -}}
 {{- end }}
 

--- a/charts/ztka/templates/_helpers.tpl
+++ b/charts/ztka/templates/_helpers.tpl
@@ -126,12 +126,14 @@ Get DSN
 {{- define "ztka.dsn" -}}
   {{- if .Values.deploy.postgresql.enable -}}
 postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{.Release.Name}}-postgresql.{{.Release.Namespace}}.svc.cluster.local:5432/{{ .Values.postgresql.auth.database }}?sslmode=disable
-  {{- else -}}
+  {{- else if empty .Values.deploy.dsn -}}
 {{- $username := required "A valid .Values.deploy.postgresql.username entry required!" .Values.deploy.postgresql.username -}}
 {{- $password := required "A valid .Values.deploy.postgresql.password entry required!" .Values.deploy.postgresql.password -}}
 {{- $address := required "A valid .Values.deploy.postgresql.address entry required!" .Values.deploy.postgresql.address -}}
 {{- $database := required "A valid .Values.deploy.postgresql.database entry required!" .Values.deploy.postgresql.database -}}
 postgres://{{ $username }}:{{ $.password }}@{{ $address }}:5432/{{ $database }}?sslmode=disable
+  {{- else -}}
+{{ .Values.deploy.dsn }}
   {{- end -}}
 {{- end }}
 

--- a/charts/ztka/templates/_helpers.tpl
+++ b/charts/ztka/templates/_helpers.tpl
@@ -126,14 +126,14 @@ Get DSN
 {{- define "ztka.dsn" -}}
   {{- if .Values.deploy.postgresql.enable -}}
 postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{.Release.Name}}-postgresql.{{.Release.Namespace}}.svc.cluster.local:5432/{{ .Values.postgresql.auth.database }}?sslmode=disable
-  {{- else if empty .Values.deploy.dsn -}}
+  {{- else if empty .Values.deploy.postgresql.dsn -}}
 {{- $username := required "A valid .Values.deploy.postgresql.username entry required!" .Values.deploy.postgresql.username -}}
 {{- $password := required "A valid .Values.deploy.postgresql.password entry required!" .Values.deploy.postgresql.password -}}
 {{- $address := required "A valid .Values.deploy.postgresql.address entry required!" .Values.deploy.postgresql.address -}}
 {{- $database := required "A valid .Values.deploy.postgresql.database entry required!" .Values.deploy.postgresql.database -}}
-postgres://{{ $username }}:{{ $.password }}@{{ $address }}:5432/{{ $database }}?sslmode=disable
+postgres://{{ $username }}:{{ $password }}@{{ $address }}:5432/{{ $database }}?sslmode=disable
   {{- else -}}
-{{ .Values.deploy.dsn }}
+{{ .Values.deploy.postgresql.dsn }}
   {{- end -}}
 {{- end }}
 

--- a/charts/ztka/values.yaml
+++ b/charts/ztka/values.yaml
@@ -205,17 +205,21 @@ deploy:
     # when true. (It is recommended to manage your own DB instance
     # separately or use DB services like Amazon RDS in production)
     enable: false
+    # -- Postgresql DSN for example, "postgres://user:password@host:5432/db". Required
+    # when `deploy.postgresql.enable` is unset and individual components are not specified.
+    # Overrides individual components (address, username, password, database)
+    dsn: ""
     # -- Postgresql address for example, "localhost:5432". Required
-    # when `deploy.postgresql.enable` is unset
+    # when `deploy.postgresql.enable` is unset and dsn is not specified.
     address: ""
     # -- Postgresql username. Required when `deploy.postgresql.enable`
-    # is unset.
+    # is unset and dsn is not specified.
     username: ""
     # -- Postgresql password. Required when `deploy.postgresql.enable`
-    # is unset.
+    # is unset and dsn is not specified.
     password: ""
     # -- Postgresql database name. Required when
-    # `deploy.postgresql.enable` is unset.
+    # `deploy.postgresql.enable` is unset and dsn is not specified.
     database: ""
 
   filebeat:

--- a/charts/ztka/values.yaml
+++ b/charts/ztka/values.yaml
@@ -12,12 +12,12 @@ images:
     name: paralus
     # -- Paralus paralus image
     repository: paralusio/paralus
-    tag: "v0.1.0"
+    tag: "v0.1.1"
   paralusInit:
     name: paralus-init
     # -- Paralus paralus initialize image
     repository: paralusio/paralus-init
-    tag: "v0.1.0"
+    tag: "v0.1.1"
   relay:
     name: relay
     # -- relay image


### PR DESCRIPTION
### What does this PR change?

Allow specifying the DSN explicitly. Fixes #44.
This PR is an extension of https://github.com/paralus/helm-charts/pull/45

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [x] Updated `CHANGELOG.md`
- [x] Ran [`helm-docs`](https://github.com/norwoodj/helm-docs) to update docs for chart (if values.yaml file was changed)
