### PR TITLE
v0.1.3 release changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [0.1.3] - 2022-08-26
+### Changed
+- Bumped paralus/paralus to 0.1.3 from [niravparikh05](https://github.com/niravparikh05)
+- Bumped paralus/relay to 0.1.1 from [niravparikh05](https://github.com/niravparikh05)
+- Bumped paralus/prompt to 0.1.1 from [niravparikh05](https://github.com/niravparikh05)
+
 ## [0.1.2] - 2022-08-12
 ### Changed
 - Bumped paralus/paralus to 0.1.2 from [meain](https://github.com/meain)
@@ -22,7 +28,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/paralus/helm-charts/compare/ztka-0.1.2...HEAD
+[Unreleased]: https://github.com/paralus/helm-charts/compare/ztka-0.1.3...HEAD
+[0.1.3]: https://github.com/paralus/helm-charts/compare/ztka-0.1.2...ztka-0.1.3
 [0.1.2]: https://github.com/paralus/helm-charts/compare/ztka-0.1.1...ztka-0.1.2
 [0.1.1]: https://github.com/paralus/helm-charts/compare/ztka-0.1.0...ztka-0.1.1
 [0.1.0]: https://github.com/paralus/helm-charts/releases/tag/ztka-0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ You should now have `paralus` deployed. You can check out our blog post to [setu
 
 From here you should be able to edit the files and repeat these steps to test it out.
 
-## Docuemntation
+## Documentation
 
 The documentation for each chart is done with [helm-docs](https://github.com/norwoodj/helm-docs). This way we can ensure that values are consistent with the chart documentation.
 

--- a/charts/ztka/Chart.yaml
+++ b/charts/ztka/Chart.yaml
@@ -25,5 +25,5 @@ dependencies:
     condition: deploy.contour.enable
 maintainers:
   - name: Paralus Team
-version: "0.1.2"
-appVersion: "v0.1.2"
+version: "0.1.3"
+appVersion: "v0.1.3"

--- a/charts/ztka/README.md
+++ b/charts/ztka/README.md
@@ -1,6 +1,6 @@
 # ztka
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.2](https://img.shields.io/badge/AppVersion-v0.1.2-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.3](https://img.shields.io/badge/AppVersion-v0.1.3-informational?style=flat-square)
 
 A Helm chart for Paralus ZTKA.
 
@@ -62,17 +62,17 @@ A Helm chart for Paralus ZTKA.
 | images.dashboard.tag | string | `"v0.1.1"` |  |
 | images.paralus.name | string | `"paralus"` |  |
 | images.paralus.repository | string | `"paralusio/paralus"` | Paralus paralus image |
-| images.paralus.tag | string | `"v0.1.2"` |  |
+| images.paralus.tag | string | `"v0.1.3"` |  |
 | images.paralusInit.name | string | `"paralus-init"` |  |
 | images.paralusInit.repository | string | `"paralusio/paralus-init"` | Paralus paralus initialize image |
-| images.paralusInit.tag | string | `"v0.1.2"` |  |
+| images.paralusInit.tag | string | `"v0.1.3"` |  |
 | images.prompt.name | string | `"prompt"` |  |
 | images.prompt.repository | string | `"paralusio/prompt"` | prompt image |
-| images.prompt.tag | string | `"v0.1.0"` |  |
+| images.prompt.tag | string | `"v0.1.1"` |  |
 | images.pullPolicy | string | `"IfNotPresent"` | If defined, a imagePullPolicy applied to all deployments |
 | images.relay.name | string | `"relay"` |  |
 | images.relay.repository | string | `"paralusio/relay"` | relay image |
-| images.relay.tag | string | `"v0.1.0"` |  |
+| images.relay.tag | string | `"v0.1.1"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |

--- a/charts/ztka/values.yaml
+++ b/charts/ztka/values.yaml
@@ -381,7 +381,7 @@ kratos:
     # OIDC Provider config synchronizer as sidecar to Kratos
     extraContainers: |
         - name: synchronizer
-          image: "paralusio/kratos-synchronizer:v0.1.2"
+          image: "paralusio/kratos-synchronizer:v0.1.3"
           volumeMounts:
             - name: other-configs
               mountPath: /etc/kratos

--- a/charts/ztka/values.yaml
+++ b/charts/ztka/values.yaml
@@ -12,22 +12,22 @@ images:
     name: paralus
     # -- Paralus paralus image
     repository: paralusio/paralus
-    tag: "v0.1.2"
+    tag: "v0.1.3"
   paralusInit:
     name: paralus-init
     # -- Paralus paralus initialize image
     repository: paralusio/paralus-init
-    tag: "v0.1.2"
+    tag: "v0.1.3"
   relay:
     name: relay
     # -- relay image
     repository: paralusio/relay
-    tag: "v0.1.0"
+    tag: "v0.1.1"
   prompt:
     name: prompt
     # -- prompt image
     repository: paralusio/prompt
-    tag: "v0.1.0"
+    tag: "v0.1.1"
   dashboard:
     name: dashboard
     # -- Paralus dashboard image


### PR DESCRIPTION
### What does this PR change?

- upgrades paralus/paralus to v0.1.3
- upgrades paralus/relay to v0.1.1
- upgrades paralus/prompt to v0.1.1

### Does the PR depend on any other PRs or Issues? If yes, please list them.

- No

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [x] Updated `CHANGELOG.md`
- [x] Ran [`helm-docs`](https://github.com/norwoodj/helm-docs) to update docs for chart (if values.yaml file was changed)
