### PR TITLE
changed default partner, org name and v0.1.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [0.1.6] - 2022-10-10
+### Changed
+- Updated default partner, organization name and image versions for paralus, dashboard from [niravparikh05](https://github.com/niravparikh05)
+
 ## [0.1.5] - 2022-09-30
 ### Changed
 - Updated image versions for relay, paralus, dashboard from [meain](https://github.com/meain)
@@ -36,7 +40,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/paralus/helm-charts/compare/ztka-0.1.5...HEAD
+[Unreleased]: https://github.com/paralus/helm-charts/compare/ztka-0.1.6...HEAD
+[0.1.6]: https://github.com/paralus/helm-charts/compare/ztka-0.1.5...ztka-0.1.6
 [0.1.5]: https://github.com/paralus/helm-charts/compare/ztka-0.1.4...ztka-0.1.5
 [0.1.4]: https://github.com/paralus/helm-charts/compare/ztka-0.1.3...ztka-0.1.4
 [0.1.3]: https://github.com/paralus/helm-charts/compare/ztka-0.1.2...ztka-0.1.3

--- a/charts/ztka/Chart.yaml
+++ b/charts/ztka/Chart.yaml
@@ -25,5 +25,5 @@ dependencies:
     condition: deploy.contour.enable
 maintainers:
   - name: Paralus Team
-version: "0.1.5"
-appVersion: "v0.1.4"
+version: "0.1.6"
+appVersion: "v0.1.5"

--- a/charts/ztka/README.md
+++ b/charts/ztka/README.md
@@ -1,6 +1,6 @@
 # ztka
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.4](https://img.shields.io/badge/AppVersion-v0.1.4-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.5](https://img.shields.io/badge/AppVersion-v0.1.5-informational?style=flat-square)
 
 A Helm chart for Paralus ZTKA.
 
@@ -59,13 +59,13 @@ A Helm chart for Paralus ZTKA.
 | imagePullSecrets | list | `[]` | If defined, uses a Secret to pull an image from a private Docker registry or repository |
 | images.dashboard.name | string | `"dashboard"` |  |
 | images.dashboard.repository | string | `"paralusio/dashboard"` | Paralus dashboard image |
-| images.dashboard.tag | string | `"v0.1.2"` |  |
+| images.dashboard.tag | string | `"v0.1.3"` |  |
 | images.paralus.name | string | `"paralus"` |  |
 | images.paralus.repository | string | `"paralusio/paralus"` | Paralus paralus image |
-| images.paralus.tag | string | `"v0.1.4"` |  |
+| images.paralus.tag | string | `"v0.1.5"` |  |
 | images.paralusInit.name | string | `"paralus-init"` |  |
 | images.paralusInit.repository | string | `"paralusio/paralus-init"` | Paralus paralus initialize image |
-| images.paralusInit.tag | string | `"v0.1.4"` |  |
+| images.paralusInit.tag | string | `"v0.1.5"` |  |
 | images.prompt.name | string | `"prompt"` |  |
 | images.prompt.repository | string | `"paralusio/prompt"` | prompt image |
 | images.prompt.tag | string | `"v0.1.1"` |  |
@@ -83,9 +83,9 @@ A Helm chart for Paralus ZTKA.
 | paralus.initialize.adminEmail | string | `"admin@paralus.local"` | Admin email address |
 | paralus.initialize.adminFirstName | string | `"Admin"` | Admin first name |
 | paralus.initialize.adminLastName | string | `"User"` | Admin last name |
-| paralus.initialize.org | string | `"DefaultOrg"` | Organization name |
+| paralus.initialize.org | string | `"ParalusOrg"` | Organization name |
 | paralus.initialize.orgDesc | string | `"Default Organization"` | Organization description |
-| paralus.initialize.partner | string | `"DefaultPartner"` | Partner name |
+| paralus.initialize.partner | string | `"Paralus"` | Partner name |
 | paralus.initialize.partnerDesc | string | `"Default Partner"` | Partner description |
 | paralus.initialize.partnerHost | string | `"paralus.local"` | Partner host |
 | podAnnotations | object | `{}` | Annotations for the all deployed pods |

--- a/charts/ztka/values.yaml
+++ b/charts/ztka/values.yaml
@@ -12,12 +12,12 @@ images:
     name: paralus
     # -- Paralus paralus image
     repository: paralusio/paralus
-    tag: "v0.1.4"
+    tag: "v0.1.5"
   paralusInit:
     name: paralus-init
     # -- Paralus paralus initialize image
     repository: paralusio/paralus-init
-    tag: "v0.1.4"
+    tag: "v0.1.5"
   relay:
     name: relay
     # -- relay image
@@ -32,7 +32,7 @@ images:
     name: dashboard
     # -- Paralus dashboard image
     repository: paralusio/dashboard
-    tag: "v0.1.2"
+    tag: "v0.1.3"
 
   # -- If defined, a imagePullPolicy applied to all deployments
   pullPolicy: IfNotPresent
@@ -157,13 +157,13 @@ paralus:
   automigrate: true
   initialize:
     # -- Partner name
-    partner: "DefaultPartner"
+    partner: "Paralus"
     # -- Partner description
     partnerDesc: "Default Partner"
     # -- Partner host
     partnerHost: "paralus.local"
     # -- Organization name
-    org: "DefaultOrg"
+    org: "ParalusOrg"
     # -- Organization description
     orgDesc: "Default Organization"
     # -- Admin email address


### PR DESCRIPTION
### What does this PR change?

- changed default partner, org name and update image versions for paralus and dashboard

### Does the PR depend on any other PRs or Issues? If yes, please list them.

-

### Checklist

I confirm, that I have...

- [ ] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
- [ ] Ran [`helm-docs`](https://github.com/norwoodj/helm-docs) to update docs for chart (if values.yaml file was changed)
