### PR TITLE
Fix password reset url command in helm upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+### Fixed
+- Fixed the NOTES.txt for helm upgrade from [akshay196](https://github.com/akshay196)
 
 ## [0.1.7] - 2022-10-14
 ### Changed

--- a/charts/ztka/templates/NOTES.txt
+++ b/charts/ztka/templates/NOTES.txt
@@ -33,5 +33,14 @@
 {{- end }}
 
 You can view the recovery link for admin user by running the following command once all the pods are running:
+{{- if .Release.IsInstall }}
 
 kubectl logs -f --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app.kubernetes.io/name='paralus' -o jsonpath='{ .items[0].metadata.name }') initialize | grep 'Org Admin signup URL:'
+{{- else if .Values.deploy.postgresql.enable }}
+
+kubectl exec -it "{{ .Release.Name }}-postgresql-0" --namespace {{ .Release.Namespace }} -- bash \
+  -c "PGPASSWORD={{ include "ztka.dbPassword" . }} psql -h {{ include "ztka.dbAddr" . }} -U {{ include "ztka.dbUser" . }} {{ include "ztka.dbName" . }} \
+-c \"select id from identities where traits->>'email' = '{{.Values.paralus.initialize.adminEmail}}' limit 1;\" -tA \
+| xargs -I{} curl -X POST http://{{ .Release.Name }}-kratos-admin/recovery/link \
+-H 'Content-Type: application/json' -d '{\"expires_in\":\"10m\",\"identity_id\":\"{}\"}'"
+{{- end }}


### PR DESCRIPTION
```
1. Access the application URL by running these commands:
  Get the EXTERNAL-IP value using following command:
  kubectl get service myrelease-contour-envoy -n default

  Add DNS records of following domains such that it resolves to above <EXTERNAL-IP> value:
  - console.paralus.local
  - *.core-connector.paralus.local
  - *.user.paralus.local

  Open http://console.paralus.local in browser.

  Note: If you are using a cluster with no load-balancer, then the address will be "<pending>".
        If it is Kind or Minikube cluster, check out respective docs to get the external address.

You can view the recovery link for admin user by running the following command once all the pods are running:

kubectl exec -it "myrelease-postgresql-0" --namespace default -- bash \
  -c "PGPASSWORD=admindbpassword psql -h myrelease-postgresql.default.svc.cluster.local -U admindbuser admindb \
-c \"select id from identities where traits->>'email' = 'admin@paralus.local' limit 1;\" -tA \
| xargs -I{} curl -X POST http://myrelease-kratos-admin/recovery/link \
-H 'Content-Type: application/json' -d '{\"expires_in\":\"10m\",\"identity_id\":\"{}\"}'"
```