### PR TITLE
fix: Don't attempt to contact kratos on https internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+- when deploying kratos as part of the chart and using TLS paralus should still connect over HTTP, and now does from [Joibel](https://github.com/Joibel)
+
 ## [0.2.4] - 2023-04-28
 
 ### Changed

--- a/charts/ztka/templates/_helpers.tpl
+++ b/charts/ztka/templates/_helpers.tpl
@@ -60,13 +60,9 @@ elasticsearch
 Get Kratos public address.
 */}}
 {{- define "ztka.kratos.publicAddr" -}}
-{{- if .Values.deploy.kratos.enable -}}
-  {{- if .Values.ingress.tls -}}
-https://{{.Release.Name}}-kratos-public
-  {{- else -}}
+  {{- if .Values.deploy.kratos.enable -}}
 http://{{.Release.Name}}-kratos-public
-  {{- end -}}
-{{- else -}}
+  {{- else -}}
 {{ required "A valid .Values.deploy.kratos.publicAddr entry required!" .Values.deploy.kratos.publicAddr }}
   {{- end -}}
 {{- end }}
@@ -75,13 +71,9 @@ http://{{.Release.Name}}-kratos-public
 Get Kratos admin address.
 */}}
 {{- define "ztka.kratos.adminAddr" -}}
-{{- if .Values.deploy.kratos.enable -}}
-  {{- if .Values.ingress.tls -}}
-https://{{.Release.Name}}-kratos-admin
-  {{- else -}}
+  {{- if .Values.deploy.kratos.enable -}}
 http://{{.Release.Name}}-kratos-admin
-  {{- end -}}
-{{- else -}}
+  {{- else -}}
 {{ required "A valid .Values.deploy.kratos.adminAddr entry required!" .Values.deploy.kratos.adminAddr }}
   {{- end -}}
 {{- end }}


### PR DESCRIPTION
### What does this PR change?

When kratos is inside the cluster it will always be on port 80 as we're contacting it via its service, not via the ingress. Don't attempt https as it won't be on 443 nor will it have a certificate.

This makes the appropriate change so Paralus's configmap uses http only for kratos when it is installed this way

### Does the PR depend on any other PRs or Issues? If yes, please list them.

No

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [N/A] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [x] Updated `CHANGELOG.md`
- [N/A] Ran [`helm-docs`](https://github.com/norwoodj/helm-docs) to update docs for chart (if values.yaml file was changed)
