### PR TITLE
chore(release): updated dependent version and chart version

### DIFF
--- a/charts/ztka/Chart.yaml
+++ b/charts/ztka/Chart.yaml
@@ -29,5 +29,5 @@ dependencies:
     condition: deploy.contour.enable
 maintainers:
   - name: Paralus Team
-version: "0.2.7"
-appVersion: "v0.2.6"
+version: "0.2.8"
+appVersion: "v0.2.7"

--- a/charts/ztka/README.md
+++ b/charts/ztka/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Paralus ZTKA.
 
-![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.6](https://img.shields.io/badge/AppVersion-v0.2.6-informational?style=flat-square)
+![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.7](https://img.shields.io/badge/AppVersion-v0.2.7-informational?style=flat-square)
 
 This chart bootstraps the Paralus deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
@@ -127,20 +127,20 @@ helm show values paralus/ztka
 | imagePullSecrets | list | `[]` | If defined, uses a Secret to pull an image from a private Docker registry or repository |
 | images.dashboard.name | string | `"dashboard"` |  |
 | images.dashboard.repository | string | `"paralusio/dashboard"` | Paralus dashboard image |
-| images.dashboard.tag | string | `"v0.2.1"` |  |
+| images.dashboard.tag | string | `"v0.2.2"` |  |
 | images.paralus.name | string | `"paralus"` |  |
 | images.paralus.repository | string | `"paralusio/paralus"` | Paralus paralus image |
-| images.paralus.tag | string | `"v0.2.6"` |  |
+| images.paralus.tag | string | `"v0.2.7"` |  |
 | images.paralusInit.name | string | `"paralus-init"` |  |
 | images.paralusInit.repository | string | `"paralusio/paralus-init"` | Paralus paralus initialize image |
-| images.paralusInit.tag | string | `"v0.2.6"` |  |
+| images.paralusInit.tag | string | `"v0.2.7"` |  |
 | images.prompt.name | string | `"prompt"` |  |
 | images.prompt.repository | string | `"paralusio/prompt"` | prompt image |
 | images.prompt.tag | string | `"v0.1.2"` |  |
 | images.pullPolicy | string | `"IfNotPresent"` | If defined, a imagePullPolicy applied to all deployments |
 | images.relay.name | string | `"relay"` |  |
 | images.relay.repository | string | `"paralusio/relay"` | relay image |
-| images.relay.tag | string | `"v0.1.6"` |  |
+| images.relay.tag | string | `"v0.1.7"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |

--- a/charts/ztka/values.yaml
+++ b/charts/ztka/values.yaml
@@ -12,17 +12,17 @@ images:
     name: paralus
     # -- Paralus paralus image
     repository: paralusio/paralus
-    tag: "v0.2.6"
+    tag: "v0.2.7"
   paralusInit:
     name: paralus-init
     # -- Paralus paralus initialize image
     repository: paralusio/paralus-init
-    tag: "v0.2.6"
+    tag: "v0.2.7"
   relay:
     name: relay
     # -- relay image
     repository: paralusio/relay
-    tag: "v0.1.6"
+    tag: "v0.1.7"
   prompt:
     name: prompt
     # -- prompt image
@@ -32,7 +32,7 @@ images:
     name: dashboard
     # -- Paralus dashboard image
     repository: paralusio/dashboard
-    tag: "v0.2.1"
+    tag: "v0.2.2"
 
   # -- If defined, a imagePullPolicy applied to all deployments
   pullPolicy: IfNotPresent
@@ -414,7 +414,7 @@ kratos:
     # OIDC Provider config synchronizer as sidecar to Kratos
     extraContainers: |
         - name: synchronizer
-          image: "paralusio/kratos-synchronizer:v0.2.6"
+          image: "paralusio/kratos-synchronizer:v0.2.7"
           volumeMounts:
             - name: other-configs
               mountPath: /etc/kratos


### PR DESCRIPTION
### What does this PR change?

- updated dependent versions and chart version

### Does the PR depend on any other PRs or Issues? If yes, please list them.

https://github.com/paralus/paralus/pull/301
https://github.com/paralus/relay/pull/109
https://github.com/paralus/dashboard/pull/242

### Checklist

I confirm, that I have...

- [ ] Read and followed the contributing guide in `CONTRIBUTING.md`
- [x] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
- [x] Ran [`helm-docs`](https://github.com/norwoodj/helm-docs) to update docs for chart (if values.yaml file was changed)
