### PR TITLE
enabled kratos.selfservice.methods.link to generate user recovery link

### DIFF
--- a/charts/ztka/values.yaml
+++ b/charts/ztka/values.yaml
@@ -300,6 +300,8 @@ kratos:
             enabled: true
           oidc:
             enabled: true
+          link:
+            enabled: true
         flows:
           settings:
             privileged_session_max_age: 15m


### PR DESCRIPTION
### What does this PR change?

- Enables kratos selfservice methods link for user's recovery url generation

### Does the PR depend on any other PRs or Issues? If yes, please list them.

- No

### Checklist

I confirm, that I have...

- [ ] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
- [ ] Ran [`helm-docs`](https://github.com/norwoodj/helm-docs) to update docs for chart (if values.yaml file was changed)
