### PR TITLE
Create configmap if Fluentbit is enabled

### DIFF
--- a/charts/ztka/Chart.yaml
+++ b/charts/ztka/Chart.yaml
@@ -29,5 +29,5 @@ dependencies:
     condition: deploy.contour.enable
 maintainers:
   - name: Paralus Team
-version: "0.2.9"
+version: "0.2.10"
 appVersion: "v0.2.8"

--- a/charts/ztka/README.md
+++ b/charts/ztka/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for Paralus ZTKA.
 
-![Version: 0.2.9](https://img.shields.io/badge/Version-0.2.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.8](https://img.shields.io/badge/AppVersion-v0.2.8-informational?style=flat-square)
+![Version: 0.2.10](https://img.shields.io/badge/Version-0.2.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.8](https://img.shields.io/badge/AppVersion-v0.2.8-informational?style=flat-square)
 
 This chart bootstraps the Paralus deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 

--- a/charts/ztka/templates/configmap-fluentbit.yaml
+++ b/charts/ztka/templates/configmap-fluentbit.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.deploy.filebeat.enable }}
+{{- if .Values.deploy.fluentbit.enable }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/ztka/templates/configmap-fluentbit.yaml
+++ b/charts/ztka/templates/configmap-fluentbit.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deploy.filebeat.enable }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -92,3 +93,4 @@ data:
         Password {{ include "ztka.dbPassword" . | }}
         Database {{ include "ztka.dbName" . | }}
         Table audit_logs
+{{- end }}


### PR DESCRIPTION
### What does this PR change?

Only create configmap for FluentBit when `deploy.filebeat.enable: true`

### Does the PR depend on any other PRs or Issues? If yes, please list them.

-

### Checklist

I confirm, that I have...

- [x] Read and followed the contributing guide in `CONTRIBUTING.md`
- [ ] Updated [documentation on the Paralus docs site](https://github.com/paralus/website/blob/main/docs) (if applicable)
- [ ] Updated `CHANGELOG.md`
- [x] Ran [`helm-docs`](https://github.com/norwoodj/helm-docs) to update docs for chart (if values.yaml file was changed)
